### PR TITLE
Weight Initialization & Layer-Specific Learning Rates

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -39,6 +39,17 @@ class GoNet(nn.Module):
                 nn.Dropout(),
                 nn.Linear(4096, 4),
                 )
+        
+        self.weight_init()
+    
+    def weight_init(self):
+        for m in self.classifier.modules():
+            # fully connected layers are weight initialized with
+            # mean=0 and std=0.005 (in tracker.prototxt) and
+            # biases are set to 1
+            if isinstance(m, nn.Linear):
+                m.bias.data.fill_(1)
+                m.weight.data.normal_(0, 0.005)
 
     # feed forward through the neural net
     def forward(self, x, y):


### PR DESCRIPTION
@amoudgl @sydney0zq After training some models on Caffe and checking the weights there, the only differences I found were:
1. Biases are initialized to 1 in Caffe (was not the case in PyTorch).
2. Weights are normally initialized with mean=0 and std= 0.005
3. Learning rates for weights and biases are different from the "overall learning rate". PyTorch does not provide support for lr_mult feature (in a direct way I mean).

The following update should show you a direct improvement on your training. For me, I get the same loss from step 100, that I used to get after ~80000 steps or so. Now, I get loss ~= 150 in the first 1000 steps which is very similar/comparable to the caffe model. Note, everything else is fixed. I am using the same training/batching code for both models.